### PR TITLE
This commit allows users to add stateful configurations to Sucker

### DIFF
--- a/lib/sucker.rb
+++ b/lib/sucker.rb
@@ -1,3 +1,4 @@
+require 'sucker/config'
 require 'sucker/request'
 require 'sucker/response'
 
@@ -17,6 +18,10 @@ module Sucker
     #
     def new(args={})
       Request.new(args)
+    end
+
+    def configure(&block)
+      yield Config
     end
   end
 end

--- a/lib/sucker/config.rb
+++ b/lib/sucker/config.rb
@@ -1,0 +1,27 @@
+module Sucker
+  class Config
+    class << self
+
+      protected
+
+      def define_configs(*configs)
+        configs.each do |config|
+          self.class.instance_eval do
+
+            define_method("#{config}=") do |value|
+              instance_variable_set("@#{config}", value)
+            end
+
+            define_method("#{config}") do
+              instance_variable_get("@#{config}")
+            end
+
+          end
+        end
+      end
+    end
+
+    define_configs :key, :secret, :associate_tag, :locale
+
+  end
+end

--- a/lib/sucker/parameters.rb
+++ b/lib/sucker/parameters.rb
@@ -35,8 +35,8 @@ module Sucker
 
     private
 
-      def timestamp
-        Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
-      end
+    def timestamp
+      Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+    end
   end
 end

--- a/lib/sucker/request.rb
+++ b/lib/sucker/request.rb
@@ -21,17 +21,27 @@ module Sucker
       end
     end
 
+    attr_writer :associate_tag, :key, :secret, :locale
+
     # The Amazon associate tag.
-    attr_accessor :associate_tag
+    def associate_tag
+      @associate_tag ||= Config.associate_tag
+    end
 
     # The Amazon Web Services access key.
-    attr_accessor :key
-
-    # The Amazon locale.
-    attr_accessor :locale
+    def key
+      @key ||= Config.key
+    end
 
     # The Amazon Web Services secret.
-    attr_accessor :secret
+    def secret
+      @secret ||= Config.secret
+    end
+
+    # The Amazon locale.
+    def locale
+      @locale ||= Config.locale
+    end
 
     # Initializes a request object.
     #

--- a/spec/sucker/config_spec.rb
+++ b/spec/sucker/config_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+module Sucker
+  describe Config do
+
+    subject { Config }
+
+    let(:key)              { "123456" }
+    let(:secret)           { "987654" }
+    let(:associate_tag)    { "foo-23" }
+
+    let(:locale)           { :en }
+
+    describe ".key" do
+      it "returns the value of @key" do
+        subject.instance_variable_set(:"@key", key)
+        subject.key.should == key
+      end
+    end
+
+    describe ".key=" do
+      it "sets @key to the passed value" do
+        subject.key = key
+        subject.instance_variable_get(:"@key").should == key
+      end
+    end
+
+    describe ".secret" do
+      it "returns the value of @secret" do
+        subject.instance_variable_set(:"@secret", secret)
+        subject.secret.should == secret
+      end
+    end
+
+    describe ".secret=" do
+      it "sets @secret to the passed value" do
+        subject.secret = secret
+        subject.instance_variable_get(:"@secret").should == secret
+      end
+    end
+
+    describe ".associate_tag" do
+      it "returns the value of @associate_tag" do
+        subject.instance_variable_set(:"@associate_tag", associate_tag)
+        subject.associate_tag.should == associate_tag
+      end
+    end
+
+    describe ".associate_tag=" do
+      it "sets @associate_tag to the passed value" do
+        subject.associate_tag = associate_tag
+        subject.instance_variable_get(:"@associate_tag").should == associate_tag
+      end
+    end
+
+    describe ".locale" do
+      it "returns the value of @locale" do
+        subject.instance_variable_set(:"@locale", locale)
+        subject.locale.should == locale
+      end
+    end
+
+    describe ".locale=" do
+      it "sets @locale to the passed value" do
+        subject.locale = locale
+        subject.instance_variable_get(:"@locale").should == locale
+      end
+    end
+  end
+end

--- a/spec/sucker_spec.rb
+++ b/spec/sucker_spec.rb
@@ -1,9 +1,18 @@
 require "spec_helper"
 
 describe Sucker do
+
+  subject { Sucker }
+
   describe ".new" do
     it "returns a Request object" do
-      Sucker.new.should be_an_instance_of Sucker::Request
+      subject.new.should be_an_instance_of Sucker::Request
+    end
+  end
+
+  describe ".configure" do
+    it "yields a Config object" do
+      subject.configure {|c| c.should == Sucker::Config }
     end
   end
 end


### PR DESCRIPTION
Currently sucker provides an extremely flexible method of configuring its requests. This makes sense for applications where multiple keys/tags/locales are in use, but for an application that really only uses one Developer/Associate account it seems a little bit redundant to repeatedly add one's configurations to each new request. This commit allows users to statefully input their configurations, and overwrite them on request initialization (if needed).
