### PR TITLE
add AU locale for australian amazon

### DIFF
--- a/lib/vacuum/request.rb
+++ b/lib/vacuum/request.rb
@@ -13,6 +13,7 @@ module Vacuum
     LATEST_VERSION = '2013-08-01'
 
     HOSTS = {
+      'AU' => 'webservices.amazon.com.au',
       'BR' => 'webservices.amazon.com.br',
       'CA' => 'webservices.amazon.ca',
       'CN' => 'webservices.amazon.cn',


### PR DESCRIPTION
This adds the AU locale to the HOSTS hash. I tested that the URL indeed works as expected. Follow up on #73 .