### PR TITLE
Revert "Remove custom parser logic"

### DIFF
--- a/lib/vacuum/response.rb
+++ b/lib/vacuum/response.rb
@@ -16,6 +16,22 @@ module Vacuum
     #   @see https://ruby-doc.org/core/Hash.html#method-i-dig
     def_delegator :to_h, :dig
 
+    class << self
+      attr_accessor :parser
+    end
+
+    def_delegator :to_h, :dig
+
+    attr_writer :parser
+
+    def parser
+      @parser || self.class.parser
+    end
+
+    def parse
+      parser ? parser.parse(body) : to_h
+    end
+
     # Casts body to Hash
     # @return [Hash]
     def to_h

--- a/test/vacuum/test_response.rb
+++ b/test/vacuum/test_response.rb
@@ -11,6 +11,10 @@ module Vacuum
       @response = Response.new(mock)
     end
 
+    def test_parse
+      assert @response.parse
+    end
+
     def test_cast_to_hash
       assert_kind_of Hash, @response.to_h
     end


### PR DESCRIPTION
I would like to return custom parser functionality. I depend on it quite heavily.

What re the downsides of having those?